### PR TITLE
Hornbach FLAIR LED

### DIFF
--- a/lib/devices.js
+++ b/lib/devices.js
@@ -1600,6 +1600,14 @@ const devices = [
         icon: 'img/livolo.png',
         states: [states.stateEp],
     },
+    // HORNBACH
+    {
+        vendor: 'HORNBACH',
+        models: ['VIYU-A60-806-RGBW-10011725'],
+        icon: 'img/flair_viyu_e27_rgbw.png',
+        states: lightStatesWithColor,
+        syncStates: [sync.brightness],
+    },
 ];
 
 const commonStates = [


### PR DESCRIPTION
Added Support for Hornbach FLAIR Viyu Smarte LED Lampe RGB E27

![flair_viyu_e27_rgbw](https://user-images.githubusercontent.com/55540912/74087716-44024680-4a8f-11ea-9779-20d57f191fcb.png)
